### PR TITLE
Allow usb hub connection for external hdd

### DIFF
--- a/kpayload/include/offsets.h
+++ b/kpayload/include/offsets.h
@@ -121,4 +121,7 @@
 // disable screenshot block
 #define disable_screenshot_patch        0x0CB8C6
 
+// allow usb hub connection for external hdd
+#define ext_hdd_usb_hub_patch           0x1A5E5F
+
 #endif

--- a/kpayload/include/offsets.h
+++ b/kpayload/include/offsets.h
@@ -121,6 +121,9 @@
 // disable screenshot block
 #define disable_screenshot_patch        0x0CB8C6
 
+// allow any usb speed specification for external hdd
+#define ext_hdd_usb_spec_patch          0x183526
+
 // allow usb hub connection for external hdd
 #define ext_hdd_usb_hub_patch           0x1A5E5F
 

--- a/kpayload/source/patch.c
+++ b/kpayload/source/patch.c
@@ -244,6 +244,11 @@ PAYLOAD_CODE int shellcore_fpkg_patch(void)
         goto error;
     }
 
+  // allow any usb speed specification for external hdd
+  ret = proc_write_mem(ssc, (void *)(text_seg_base + ext_hdd_usb_spec_patch), 6, "\x90\x90\x90\x90\x90\x90", &n);
+  if (ret)
+    goto error;
+
   // allow usb hub connection for external hdd
   ret = proc_write_mem(ssc, (void *)(text_seg_base + ext_hdd_usb_hub_patch), 8, "\x31\xC0\x90\x90\x90\x90\x90\x90", &n);
   if (ret)

--- a/kpayload/source/patch.c
+++ b/kpayload/source/patch.c
@@ -244,6 +244,11 @@ PAYLOAD_CODE int shellcore_fpkg_patch(void)
         goto error;
     }
 
+  // allow usb hub connection for external hdd
+  ret = proc_write_mem(ssc, (void *)(text_seg_base + ext_hdd_usb_hub_patch), 8, "\x31\xC0\x90\x90\x90\x90\x90\x90", &n);
+  if (ret)
+    goto error;
+
 error:
 	if (entries)
 		dealloc(entries);


### PR DESCRIPTION
The PS4 will give the error below if external storage is not connected directly to a single usb port. This ShellCore patch bypasses that requirement.

It's useful for those who want to use more than one usb hub or dedicate one port for usb audio while still having the ability to run off the external hdd.

![image](https://user-images.githubusercontent.com/13112103/92314610-fac79600-ef8e-11ea-9d1a-81fddf78a0ab.png)

I've also added a patch to bypass the usb 3.0 speed specification check. This allows usb 2.0 external drives to be connected.

Please note that these patches do NOT cover the extended storage format process. The external hdd must still directly be connected with usb 3.0 for the initial format.

Second note is if using a hub, the hdd should be connected AFTER enabling Hen otherwise the PS4 will fail to use the drive as extended storage. This is slightly inconvenient however we shouldn't be having external drives connected while triggering the exploit anyway.

// 5.05 offsets
`#define ext_hdd_usb_spec_patch          0x183526`
`#define ext_hdd_usb_hub_patch           0x1A5E5F`

// 6.72 offsets
`#define ext_hdd_usb_spec_patch          0x19CB5F`
`#define ext_hdd_usb_hub_patch           0x1C65F1`