### PR TITLE
Never block out screen for remote play

### DIFF
--- a/kpayload/include/offsets.h
+++ b/kpayload/include/offsets.h
@@ -87,6 +87,14 @@
 #define SceRemotePlay_patch1                                        0x03C33F
 #define SceRemotePlay_patch2                                        0x03C35A
 
+// call sceVshAvcapSetInfo
+#define sceVshAvcapSetInfo_patch1       0x226A36
+#define sceVshAvcapSetInfo_patch2       0x226A75
+#define sceVshAvcapSetInfo_patch3       0x226AA5
+#define sceVshAvcapSetInfo_patch4       0x226B43
+#define sceVshAvcapSetInfo_patch5       0x226B7B
+#define sceVshAvcapSetInfo_patch6       0x226BEC
+
 // SceShellCore patches
 // call sceKernelIsGenuineCEX
 #define sceKernelIsGenuineCEX_patch1    0x16D05B

--- a/kpayload/source/patch.c
+++ b/kpayload/source/patch.c
@@ -351,6 +351,16 @@ PAYLOAD_CODE int remoteplay_patch() {
 
     int ret = 0;
 
+    uint32_t call_ofs_for__xor__eax_eax__3nop[] = {
+      // call sceVshAvcapSetInfo
+      sceVshAvcapSetInfo_patch1,
+      sceVshAvcapSetInfo_patch2,
+      sceVshAvcapSetInfo_patch3,
+      sceVshAvcapSetInfo_patch4,
+      sceVshAvcapSetInfo_patch5,
+      sceVshAvcapSetInfo_patch6,
+    };
+
     struct proc *srp = proc_find_by_name("SceRemotePlay");
 
     if (!srp) {
@@ -386,7 +396,14 @@ PAYLOAD_CODE int remoteplay_patch() {
         goto error;
     }
 
-    error:
+    // never block out screen for remote play
+    for (int i = 0; i < COUNT_OF(call_ofs_for__xor__eax_eax__3nop); i++) {
+      ret = proc_write_mem(srp, (void *)(executable_base + call_ofs_for__xor__eax_eax__3nop[i]), 5, "\x31\xC0\x90\x90\x90", &n);
+      if (ret)
+        goto error;
+    }
+
+error:
     if (entries) {
         dealloc(entries);
     }


### PR DESCRIPTION
Some games including VR will block out the screen for remote play. A pop up message will still appear to the user that the screen is blocked however with this patch, the screen will remain open.

This seems to work only with video output as audio still seems to be blocked. My goal was to also unblock video recording however there are more patches needed to bypass that.