### PR TITLE
hen 2.1.3b for 9.00

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PS4HEN v2.1.3
+# PS4HEN v2.1.3b
 
 ## Features
 - Homebrew Enabler
@@ -16,6 +16,7 @@
 - UART Enabler
 - Never Disable Screenshot
 - Remote Play Enabler
+- Fake Dex To Fix Blank Trophy Date Problem
 
 ## Contributors
 Massive credits to the following:

--- a/installer/include/defines.h
+++ b/installer/include/defines.h
@@ -2,7 +2,7 @@
 #define __DEFINES_H__
 #pragma once
 
-#define VERSION "2.1.3"
+#define VERSION "2.1.3b"
 
 //#define DEBUG_SOCKET
 
@@ -10,6 +10,7 @@
 #define LOG_PORT 9023
 
 #define FAKE_FW_VERSION 0x07518021
+#define FAKE_DEX        0x0C100080
 
 struct filedesc {
 	void *useless1[3];

--- a/installer/include/offsets.h
+++ b/installer/include/offsets.h
@@ -9,7 +9,7 @@
 #define PRISON0_addr                    0x113E518
 #define ROOTVNODE_addr                  0x2300320
 #define PMAP_STORE_addr                 0x1BB7880
-#define DT_HASH_SEGMENT_addr            0x0D09FB0
+#define DT_HASH_SEGMENT_addr            0x0C00468
 
 // Functions
 #define pmap_protect_addr               0x050F50

--- a/installer/include/offsets.h
+++ b/installer/include/offsets.h
@@ -32,6 +32,7 @@
 
 // sdk version spoof - enable all VR fws
 #define sdk_version_patch               0x1A84248
+#define fake_dex_patch                  0x1BD800D
 
 // enable debug log
 #define enable_debug_log_patch          0x0123367

--- a/installer/source/main.c
+++ b/installer/source/main.c
@@ -75,8 +75,9 @@ int install_payload(struct thread *td, struct install_payload_args* args)
 	// flatz allow sys_dynlib_dlsym in all processes 6.72
 	*(uint64_t*)(kernel_base + sys_dynlib_dlsym_patch) = 0x8B4890000001C7E9;
 
-	// spoof sdk_version - enable vr
+	// spoof sdk_version - enable vr and fake dex
 	*(uint32_t *)(kernel_base + sdk_version_patch) = FAKE_FW_VERSION;
+	*(uint32_t *)(kernel_base + fake_dex_patch) = FAKE_DEX;
 
 	// enable debug log
 	*(uint16_t*)(kernel_base + enable_debug_log_patch) = 0x38EB;


### PR DESCRIPTION
please leeful 
Do you think you could release hen 2.1.3b for 9.00 because this version uses internal clock to fix blank trophy timestamp (Fake Dex To Fix Blank Trophy Date Problem)

